### PR TITLE
Added common vim-style search keyboard shortcut.

### DIFF
--- a/themes/base.html
+++ b/themes/base.html
@@ -166,6 +166,16 @@
 			});
 		</script>
 
+        <script type="text/javascript">
+            $(function() {
+                $(document).keyup(function(e) {
+                    if ($("input:focus, textarea:focus").length === 0 && e.which === 191) {
+                        $("#searchbox").focus();
+                    }
+                });
+            });
+        </script>
+
 		{% block script %}
 		{% endblock %}
 


### PR DESCRIPTION
If no text box is currently in focus, pressing forwardslash should set focus to the search box.

This is pretty common among websites (twitter, facebook, github, etc) and helpful for programming nerds.