### PR TITLE
Dirty performance improvement for large related kills pages.

### DIFF
--- a/classes/Info.php
+++ b/classes/Info.php
@@ -2,15 +2,24 @@
 
 class Info
 {
+    /**
+     * @var array  Used for static caching of getInfoField results
+     */
+    static $infoFieldCache;
+
     public static function getInfoField($type, $id, $field)
     {
         global $mdb, $redis;
+        $key = "$type . $id . $field";
+        if (isset(self::$infoFieldCache[$key])) {
+            return self::$infoFieldCache[$key];
+        }
 
         $data = $redis->hGet("tq:$type:$id", $field);
         if ($data == null) {
             $data = $mdb->findField('information', "$field", ['type' => $type, 'id' => (int) $id, 'cacheTime' => 300]);
         }
-
+        self::$infoFieldCache[$key] = $data;
         return $data;
     }
 


### PR DESCRIPTION
Because the same field will be queried many many times the additional in-mem caching cuts a lot of the overhead.

Ideally the code should be refactored to not need to call the data so often, but once I found the bottleneck it was fairly easy to introduce this fix, so why not.

For reference, on the bacc event BR the method was called 243,246 times.
After adding the caching it hit the inner part 9,874 times. 
https://zkillboard.com/related/30003792/201512052100/

The fix will do mostly nothing for smaller BR's since there will be very little overlap in characters/ships/etc...