### PR TITLE
make the price of dropped items stand out a bit

### DIFF
--- a/public/css/style-edits/cyborg-main.css
+++ b/public/css/style-edits/cyborg-main.css
@@ -35,6 +35,9 @@ color: black;
 .item_dropped_row {
 	background-color: #001600;
 }
+.item_dropped_row .price {
+	color: white;
+}
 .item_dropped {
 	color: white;
 }


### PR DESCRIPTION
up to you if you want this or not. maybe I'm getting old but it's sometimes hard to tell what dropped and didn't with the background and the tinting and the lighting and whatever else.

here's what a random killmail (from latest) would look like with this in:
<img width="798" alt="screen shot 2016-01-14 at 10 27 38 pm" src="https://cloud.githubusercontent.com/assets/1832772/12346996/4ccd24de-bb0e-11e5-8ea8-b3b62d4a74d5.png">