### PR TITLE
Added spacer between key parameters, to prevent duplicates.

### DIFF
--- a/classes/Info.php
+++ b/classes/Info.php
@@ -10,7 +10,7 @@ class Info
 	public static function getInfoField($type, $id, $field)
 	{
 		global $mdb, $redis;
-		$key = "$type . $id . $field";
+		$key = $type . ':' . $id . ':' . $field;
 		if (isset(self::$infoFieldCache[$key])) {
 			return self::$infoFieldCache[$key];
 		}


### PR DESCRIPTION
I added spacers between the key parameters to prevent unseen duplicates. I looked into the code and saw most spacers you use are : so i sticked to those.

**Example:**
type = 12
id = 34
field = 56 
would generate 123456

type = 123
id = 4
field = 56 
would also generate 123456 but both should return different results