### PR TITLE
Improve notification handling

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -110,6 +110,8 @@ function htmlNotify (data)
             });
             notif.onclick = function () {
                 window.location = data.url;
+                window.focus();
+                notif.close();
             };
         }
     }


### PR DESCRIPTION
When the notification is clicked on, in addition to navigating to the killmail, focus on the window and close the notification.