### PR TITLE
Fix the type of "activepvp" in the stats API

### DIFF
--- a/view/apistats.php
+++ b/view/apistats.php
@@ -15,7 +15,7 @@ try {
     $array = $mdb->findDoc('statistics', ['type' => $type, 'id' => $id]);
     unset($array['_id']);
 
-    $array['activepvp'] = Stats::getActivePvpStats([$type => [$id]]);
+    $array['activepvp'] = (object) Stats::getActivePvpStats([$type => [$id]]);
     $array['info'] = $mdb->findDoc('information', ['type' => $type, 'id' => $id]);
     unset($array['info']['_id']);
 


### PR DESCRIPTION
This should always be an object, even if it's empty.

Old Examples:
`"activepvp":[]`
`"activepvp":{"kills":{"type":"Total Kills","count":6}}`

New Examples:
`"activepvp":{}`
`"activepvp":{"kills":{"type":"Total Kills","count":6}}`

This change casts it to `(object)` in the API view.