### PR TITLE
Add mongodb filter for involvedLimit

### DIFF
--- a/classes/MongoFilter.php
+++ b/classes/MongoFilter.php
@@ -244,6 +244,9 @@ class MongoFilter
                 case 'beforeSequence':
                     $and[] = ['sequence' => ['$lt' => $value]];
                     break;
+                case 'involvedLimit':
+                    $and[] = ['$where' => 'this.attackers.length < ' . $value];
+                    break;
             }
         }
 


### PR DESCRIPTION
Would be cool to cap `attackers` for usage in finding small-gang killmails.

[SO example](https://stackoverflow.com/questions/7811163/query-for-documents-where-array-size-is-greater-than-1)