### PR TITLE
remove hidden-xs from dropped/destroyed ship+totals

### DIFF
--- a/templates/components/item_list.html
+++ b/templates/components/item_list.html
@@ -20,26 +20,26 @@
 		<td class="hidden"></td>
 	</tr>
 	{% set imageSize = 32 %}
-	<tr class="hidden-xs">
+	<tr>
 	{% set field = killdata.victim %}
 		<td class="icons hidden-xs"><div align="center">{% include 'components/image_ship.html' %}</div></td>
 		<td><a href="/item/{{killdata.victim.shipTypeID}}/">{{killdata.victim.shipName}}</a></td>
 		<td><div align="right" class="qty">1</div></td>
 		<td class="price"><div align="right">{{ extra.shipprice|number_format(2, '.', ',') }}</div></td>
 	</tr>
-	<tr class="item_dropped_row hidden-xs hide-when-sorted">
+	<tr class="item_dropped_row hide-when-sorted">
 		<td colspan="2"><h5>Total Dropped:</h5></td>
 		<td colspan="2" style="text-align: right;"><div class="pull-right" style="width: 100%;"><h5 class="item_dropped" rel="tooltip" title="&#36;{{ extra.droppedprice.usd|number_format(2, '.', ',') }} / {{ extra.droppedprice.eur|number_format(2, '.', ',') }}&euro; / &pound;{{ extra.droppedprice.gbp|number_format(2, '.', ',') }}">{{ extra.droppedisk|number_format(2, '.', ',')}}</h5></div></td>
 <td class="hidden"></td>
 <td class="hidden"></td>
 	</tr>
-	<tr class="hidden-xs hide-when-sorted">
+	<tr class="hide-when-sorted">
 		<td colspan="2"><h5>Total Destroyed:</h5></td>
 		<td colspan="2" style="text-align: right;"><div class="pull-right" style="width: 100%;"><h5 class="item_destroyed" rel="tooltip" title="&#36;{{ extra.destroyedprice.usd|number_format(2, '.', ',') }} / {{ extra.destroyedprice.eur|number_format(2, '.', ',') }}&euro; / &pound;{{ extra.destroyedprice.gbp|number_format(2, '.', ',') }}">{{ extra.lostisk|number_format(2, '.', ',')}}</h5></div></td>
 <td class="hidden"></td>
 <td class="hidden"></td>
 	</tr>
-	<tr class="hidden-xs hide-when-sorted">
+	<tr class="hide-when-sorted">
 		<td colspan="2"><h5>Grand Total:</h5></td>
 		<td colspan="2" style="text-align: right;" class="totalprice"><div class="pull-right" style="width: 100%;"><h5 rel="tooltip" title="&#36;{{ extra.totalprice.usd|number_format(2, '.', ',') }} / {{ extra.totalprice.eur|number_format(2, '.', ',') }}&euro; / &pound;{{ extra.totalprice.gbp|number_format(2, '.', ',') }}">{{ (extra.lostisk + extra.droppedisk)|number_format(2, '.', ',')}}</h5></div></td>
 <td class="hidden"></td>


### PR DESCRIPTION
When viewing a killmail, screen sizes smaller than ~767px currently hide the destroyed ship row as well as the "Total Dropped", "Total Destroyed", and "Grand Total" rows. I think this should not occur, as it is useful information that does not negatively impact viewing the site at such a small size.

This pull request removes that CSS class from the affected rows.