### PR TITLE
Set default sort order on item list price column to descending

### DIFF
--- a/public/js/rankstablesort.js
+++ b/public/js/rankstablesort.js
@@ -96,7 +96,7 @@ $(document).ready(function()
                 { "sType" : "string" },
                 { "sType" : "string" },
                 { "sType" : "numeric-comma" },
-                { "sType" : "numeric-comma" }
+                { "sType" : "numeric-comma", "asSorting": [ "desc", "asc" ] }
                 ]
                 } );
         } 


### PR DESCRIPTION
The most common use case for sorting this column is most likely seeing the most expensive items, not the least. This changes the default sort order from ascending to descending.

My first PR here, apologies if I'm doing something a bit off.

I am slightly concerned that the column is positional and there's no comment about which is the price column, but this doesn't seem to make that any worse.