### PR TITLE
Relocate Kill Detail Alert

### DIFF
--- a/templates/detail.html
+++ b/templates/detail.html
@@ -103,6 +103,15 @@
 </div>
 
 <div class="col-lg-4">
+	        {% if extra.npcOnly %}
+		<div class="alert alert-info">This is an NPC Only killmail.<br/>It is not counted in statistics.</div>
+		{% endif %}
+		{% if killdata.info.solo %}
+		<div class="alert alert-success"><center>Solo Killmail</center></div>
+		{% endif %}
+		{% if killdata.info.ganked %}
+		<div class="alert alert-danger"><center>GANKED</center></div>
+		{% endif %}
 		<div class="tab-pane fade in active" id="details">
 			{% if extra.warInfo.dscr %}
 			<div>
@@ -121,15 +130,7 @@
 			{% endif %}
 			<!--<div><small>Kill Added: {{ extra.insertTime }}</small></div>-->
 		</div>
-        {% if extra.npcOnly %}
-        <br/><div class="alert alert-info">This is an NPC Only killmail.<br/>It is not counted in statistics.</div>
-        {% endif %}
-        {% if killdata.info.solo %}
-        <br/><div class="alert alert-success"><center>Solo Killmail</center></div>
-        {% endif %}
-        {% if killdata.info.ganked %}
-        <br/><div class="alert alert-danger"><center>GANKED</center></div>
-        {% endif %}
+
 <hr/>
 <div id="commentblock"></div>
 </div>


### PR DESCRIPTION
Moves the Ganked, Solo, and NPC Alert on the Kill Detail page to the top of the Attackers column. On large kills, this message is hidden off of the page. What is the point of having an alert such as this if nobody can see it? This really only pertains to Ganked Kills such as
https://zkillboard.com/kill/69516063/