### PR TITLE
Added Poop Emoji to Comments

### DIFF
--- a/classes/Comments.php
+++ b/classes/Comments.php
@@ -6,6 +6,7 @@ class Comments
     public static $defaultComments = ['DUNKED', 'another one', 'nothing of value was lost', 
                                         'memed', 'baited on a free ____', 'it would have lived if it were a shield super', 'RMT', 'wrong rigs', 'WTF?',
                                         '🎺 ', 'meh', 'already replaced',
-                                        'loot fairy said no', 'press F to pay respects', 'good fight!', "needs more purple",
+                                        'loot fairy said no', 'press F to pay respects', 'good fight!', 'needs more purple',
+                                        '💩',
                                     ];
 }


### PR DESCRIPTION
A friend wanted me to ask Squizz if zKB could get a poop emoji because her own friend likes plastering it on wacky killmails in Discord, but Tweetfleet `#zkillboard` said to open a pull request with the change.  Why are we like this?  I don't know.

Serious details: I looked for places the database might need to be updated, but didn't see anything obvious.  As far as I can tell, it really just is adding new ones to the end to not disrupt the existing comment order.