### PR TITLE
Add trailing slash for 10b nav. item

### DIFF
--- a/templates/navigationbar.html
+++ b/templates/navigationbar.html
@@ -35,7 +35,7 @@
 						<li><a href="/kills/w-space/">W-Space</a></li>
 						<li class="divider"></li>
 						<li><a href="/kills/5b/">+5b</a></li>
-						<li><a href="/kills/10b">+10b</a></li>
+						<li><a href="/kills/10b/">+10b</a></li>
 						<li class="divider"></li>
 						<li><a href="/kills/capitals/">Capitals</a></li>
 						<li><a href="/kills/freighters/">Freighters</a></li>


### PR DESCRIPTION
The 10b/ drop down item for the "Menu" in the navigation bar is missing a `/`. 