### PR TITLE
update Github to GitHub in footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -13,7 +13,7 @@
             <a href="/information/faq/">FAQ</a> /
             <a href="/information/legal/">Legal</a>
             <a href="/information/about/">About</a> / 
-            <a target='_blank' href="https://github.com/zKillboard/zKillboard">Github</a> / 
+            <a target='_blank' href="https://github.com/zKillboard/zKillboard">GitHub</a> / 
             <a href="https://twitter.com/zkillboard" target="blank">Twitter</a><br/>
             {{ pageTimer()|number_format() }}ms. / {{ queryCount() }}q
         </div>


### PR DESCRIPTION
adjust the spelling of `GitHub` in the footer to follow the official spelling with an uppercase `H`.

sorry for opening a PR about that, but I couldn't unsee it again :)