### PR TITLE
nit: Missing separator in the footer menu

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -11,7 +11,7 @@
             <a href="/information/payments/">Payments</a> /
             <a href="https://github.com/zKillboard/zKillboard/wiki" target="_blank">API</a> /
             <a href="/information/faq/">FAQ</a> /
-            <a href="/information/legal/">Legal</a>
+            <a href="/information/legal/">Legal</a> /
             <a href="/information/about/">About</a> / 
             <a target='_blank' href="https://github.com/zKillboard/zKillboard">GitHub</a> / 
             <a href="https://twitter.com/zkillboard" target="blank">Twitter</a><br/>


### PR DESCRIPTION
There's a missing separator between `Legal` and `About`.
![Screen Shot 2021-04-09 at 3 29 11 PM](https://user-images.githubusercontent.com/1076859/114246779-5ce2e200-9948-11eb-8fca-bbfa23afbd30.png)
