### PR TITLE
added top10 recent/alltime to nav menu

### DIFF
--- a/templates/navigationbar.html
+++ b/templates/navigationbar.html
@@ -41,6 +41,9 @@
 						<li><a href="/kills/freighters/">Freighters</a></li>
 						<li><a href="/kills/rorquals/">Rorquals</a></li>
 						<li><a href="/kills/supers/">Supers</a></li>
+						<li class="divider"></li>
+						<li><a href="/ranks/recent/killers/">Top 10 Recent</a></li>
+						<li><a href="/ranks/alltime/killers/">Top 10 Alltime</a></li>
 					</ul>
 				</li>
 				<li class="dropdown hidden-xs hidden-sm" id="tracker-menu">


### PR DESCRIPTION
added [recent](https://zkillboard.com/ranks/recent/killers/) and [alltime](https://zkillboard.com/ranks/alltime/killers/) to the navmenu (at the bottom), apparently they've never been there before.

