### PR TITLE
Hourly Stats automatically goes to w-space

### DIFF
--- a/templates/navigationbar.html
+++ b/templates/navigationbar.html
@@ -35,10 +35,10 @@
 						<li><a href="/kills/rorquals/">Rorquals</a></li>
 						<li><a href="/kills/supers/">Supers</a></li>
 						<li class="divider"></li>
-                        <li><a href="/top/lasthour/w-space/">Hourly Stats</a><li>
+                        			<li><a href="/top/lasthour/all/">Hourly Stats</a><li>
 						<li><a href="/ranks/recent/killers/">Top 10 Recent</a></li>
 						<li><a href="/ranks/alltime/killers/">Top 10 Alltime</a></li>
-                        <li><a href="/ztop/">zTop</a></li>
+                        			<li><a href="/ztop/">zTop</a></li>
 					</ul>
 				</li>
 				<li class="dropdown hidden-xs hidden-sm" id="tracker-menu">


### PR DESCRIPTION
The Menu link for `Hourly Stats` does link to `/top/lasthour/w-space/` while it should probably link to `/top/lasthour/all/`.