### PR TITLE
feat(menu preset): add label/preset for viewing capital kills

### DIFF
--- a/templates/navigationbar.html
+++ b/templates/navigationbar.html
@@ -17,6 +17,8 @@
 						<li class="divider"></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-5b+","sort-date","sort-desc","page1","victimsonly"]}'>Toy Kills (5b+)</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-10b+","sort-date","sort-desc","page1","victimsonly"]}'>Big Kills (10b+)</a></li>
+						<li><a href='/asearch/#{"buttons":["week","rolling","label-capital","label-pvp","sort-date","sort-desc","page1","victimsonly"]}'>Capitals</a></li>
+						<li><a href='/asearch/#{"buttons":["week","rolling","label-cat:65","label-pvp","sort-date","sort-desc","page1","victimsonly"]}'>Structures</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-abyssal","sort-date","sort-desc","page1","victimsonly"]}'>Abyssal</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-abyssal","label-pvp","sort-date","sort-desc","page1","victimsonly"]}'>Abyssal PvP</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-awox","sort-date","sort-desc","page1","victimsonly"]}'>Awox</a></li>


### PR DESCRIPTION
Using a hardcoded list of ship TypeIds for all capital ships (obtained
here: https://everef.net/market/1381/all), this commit adds support for
a filter for all killmails where the victim's ship is a capital ship.

This offers a new way to view specifically capital ship lossmails, which
is only partially served currently by the 5b+ value filter.

Signed-off-by: Sean Pianka <pianka@eml.cc>