### PR TITLE
feat: add Menu entries for PVP Capital and Structure mails

### DIFF
--- a/templates/navigationbar.html
+++ b/templates/navigationbar.html
@@ -17,6 +17,8 @@
 						<li class="divider"></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-5b+","sort-date","sort-desc","page1","victimsonly"]}'>Toy Kills (5b+)</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-10b+","sort-date","sort-desc","page1","victimsonly"]}'>Big Kills (10b+)</a></li>
+						<li><a href='/asearch/#{"buttons":["week","rolling","label-capital","label-pvp","sort-date","sort-desc","page1","victimsonly"]}'>Capitals</a></li>
+						<li><a href='/asearch/#{"buttons":["week","rolling","label-cat:65","label-pvp","sort-date","sort-desc","page1","victimsonly"]}'>Structures</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-abyssal","sort-date","sort-desc","page1","victimsonly"]}'>Abyssal</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-abyssal","label-pvp","sort-date","sort-desc","page1","victimsonly"]}'>Abyssal PvP</a></li>
 						<li><a href='/asearch/#{"buttons":["week","rolling","label-awox","sort-date","sort-desc","page1","victimsonly"]}'>Awox</a></li>


### PR DESCRIPTION
Using the new advanced search filtering for capitals and structures,
this commit adds easily discoverable entries in the page template
for viewing PVP capital and structure lossmails.

Signed-off-by: Sean Pianka <pianka@eml.cc>