### PR TITLE
  Minor fixes of links and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 zKillboard is a killboard created for EVE-Online, for use on zkillboard.com, but can also be used for single entities.
 
 
-Fun fact: zKillboard.com was originally called killwhore.com until it was discovered that the Eve Online forums censored the word whore.
+Fun fact: zKillboard.com was originally called killwhore.com until it was discovered that the EVE Online forums censored the word whore.
 
 ## Installation
 This is a set of code that is beta and is constantly in flux. Which means it is a work in progress.  It lacks complete documentation and is currently not meant for use by those who do not have a lot of experience in setting up PHP, TokuDB (a derivative of MongoDB), and Redis. Please feel free to attempt to install zKillboard on your own server, however, we are not responsible for any difficulties you come across during installation and continuing execution.
@@ -26,11 +26,11 @@ The cron.sh file handles the output as well as rotating of the logfiles in /cron
 
 ## Credits
 zKillboard is released under the GNU Affero General Public License, version 3. The full license is available in the `AGPL.md` file.
-zKillboard also uses data and images from EVE-Online, which is covered by a separate license from _[CCP](http://www.ccpgames.com)_. You can see the full license in the `CCP.md` file.
+zKillboard also uses data and images from EVE-Online, which is covered by a separate license from _[CCP](https://www.ccpgames.com)_. You can see the full license in the `CCP.md` file.
 It also uses various 3rd party libraries, which all carry their own licensing. Please refer to them for more info.
 
 #### License and Copyright
-Licensing for all files in this repository can be found in in AGPL.md
+Licensing for all files in this repository can be found in AGPL.md
 
 ### History and previous versions
 zKillboard.com came as the brainchild of Squizz Caphinator who wanted to improve upon [Eve-Dev Killboard](http://wiki.eve-id.net/EDK). Squizz decided to write a new killboard completely from scratch and began the zKillboard project. Karbowiak of eve-kill.net eventually joined into the project, contributed much code, [created a repository on Github](https://github.com/EVE-KILL/zKillboard), and announced zKillboard as the new Beta killboard for eve-kill.net. zKillboard matured and gained a fanbase, and of course, haters. As time went on Squizz and Karbowiak had some differences and Squizz forked his code into this repository and made this new repository the primary code base for zkillboard.com. After about a year Squizz then began dabbling in NoSQL, as it seemed the perfect database for the type of data consumed by zKillboard. Two months of heavy coding and extreme database changes, the repository [zKillboard/zKillboard](https://github.com/zKillboard/zKillboard) was updated to make the code public to the masses with the various NoSQL changes.

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,8 +1,8 @@
 <div class="footer" style="margin-bottom: 1em;">
     <hr/>
     <div class="row">
-        <div class="col-md-4 cenetered">
-            All <a href="/information/legal/">EVE related materials</a> are property of <a href="http://www.ccpgames.com">CCP Games</a><br/>
+        <div class="col-md-4 centered">
+            All <a href="/information/legal/">EVE related materials</a> are property of <a href="https://www.ccpgames.com">CCP Games</a><br/>
         </div>
         <div class="col-md-4 centered" >
             <a target="_blank" rel="noopener noreferrer" href="https://www.eveonline.com/partners"><img src="/img/eo_pp.png" style="width: 300px;" alt="Eve Online Partnership Program" /></a>

--- a/view/detail.php
+++ b/view/detail.php
@@ -81,7 +81,7 @@ $insDate = (int) str_replace('-', '', substr($killdata['info']['dttm'], 0, 10));
 $extra['insurance'] = $mdb->findDoc('insurance', ['typeID' => (int) $killdata['victim']['shipTypeID'], 'date' => ['$lte' => $insDate]], ['date' => -1]);
 if (isset($extra['insurance']['Platinum']['payout'])) {
     // No insurance is 40% of platinum
-    // http://wiki.eveuniversity.org/Insuring_your_ship
+    // https://wiki.eveuniversity.org/Insurance
     $extra['insurance']['None'] = ['cost' => 0, 'payout' => floor(0.4 * $extra['insurance']['Platinum']['payout'])];
 }
 


### PR DESCRIPTION
Update links and use https for speed and security. Fix some of the typos in the comments for increased readability. Fix div class typo. Update the readme link and use stylized EVE. Choose a better UniWiki link. New request because of lack of git knowledge see #291 