### PR TITLE
Update 9.listenRedisQ.php to new redisq URL

### DIFF
--- a/cron/9.listenRedisQ.php
+++ b/cron/9.listenRedisQ.php
@@ -12,7 +12,7 @@ if ($listenRedisQID === null) {
 }
 
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, "https://redisq.zkillboard.com/listen.php?queueID=$listenRedisQID");
+curl_setopt($ch, CURLOPT_URL, "https://zkillredisq.stream/listen.php?queueID=$listenRedisQID");
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
 $minute = date('Hi');


### PR DESCRIPTION
This pull request includes a small update to the URL used in the `cron/9.listenRedisQ.php` file. The change replaces the RedisQ endpoint with a new URL for listening to the queue.

* [`cron/9.listenRedisQ.php`](diffhunk://#diff-d5e1c3ae547dcbac138c72ccc548e33f046a10db4ef796ea2a025afd71d8c587L15-R15): Updated the URL in the `curl_setopt` function from `https://redisq.zkillboard.com/listen.php` to `https://zkillredisq.stream/listen.php`.