### PR TITLE
#339 use rawurldecode in /asearchsave/ to preserve the "+" characters value filters

### DIFF
--- a/view/asearchsave.php
+++ b/view/asearchsave.php
@@ -5,7 +5,7 @@ global $mdb;
 $URLBASE = "https://zkillboard.com/asearch/";
 
 try {
-    $url = urldecode((string) @$_GET['url']);
+    $url = rawurldecode((string) @$_GET['url']);
     $record = $mdb->findDoc("shortener", ['url' => $url]);
     if ($record == null) {
         if (substr($url, 0, strlen($URLBASE)) != $URLBASE) throw new Exception("invalid domain: $url");


### PR DESCRIPTION
Fixes #339 

I will admit I did not set up a full local environment to test this change in action, I only tested those specific lines.