### PR TITLE
Fixed an issue preventing individual ships from being used in a filter.

### DIFF
--- a/public/js/asearch.js
+++ b/public/js/asearch.js
@@ -755,6 +755,7 @@ function buildZkillbotFilter() {
 		'corporationID':  'corporation_id',
 		'allianceID':     'alliance_id',
 		'factionID':      'faction_id',
+		'shipID':         'ship_type_id',
 		'shipTypeID':     'ship_type_id',
 		'groupID':        'group_id',
 		'systemID':       'solar_system_id',


### PR DESCRIPTION
`shipID` field was missing in the field map, as a result individual ships could not be added to a filter.