### PR TITLE
Potential fix for code scanning alert no. 35: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/typeranks.js
+++ b/public/js/typeranks.js
@@ -85,8 +85,10 @@ function updateSoloBtn() {
 
 function updatePageBtn() {
     const t = $(this);
-    const page = t.text();
+    const pageText = t.text().trim();
+    const page = Number.parseInt(pageText, 10);
     if (t.css('display') == 'none') return t.remove();
+    if (!Number.isFinite(page) || page < 1) return t.remove();
     t.attr('href', buildURL(ranksType, ranksKL, ranksGroup, ranksEpoch, page, ranksSortKey, ranksSortDir));
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/zKillboard/zKillboard/security/code-scanning/35](https://github.com/zKillboard/zKillboard/security/code-scanning/35)

General fix: do not feed raw DOM text into URL/HTML-producing logic. Normalize and validate it first (allow only expected numeric pagination values), and skip/remove invalid buttons.

Best targeted fix (without changing intended behavior): in `updatePageBtn()` (around lines 86–91), replace `const page = t.text();` with strict parsing of `t.text()` to an integer, reject non-finite or `< 1` values, then pass the sanitized numeric `page` to `buildURL`.

Changes needed in `public/js/typeranks.js` only:
- In `updatePageBtn`, introduce:
  - `const pageText = t.text().trim();`
  - `const page = Number.parseInt(pageText, 10);`
  - guard `if (!Number.isFinite(page) || page < 1) return t.remove();`
- Keep existing display-none check and href assignment logic.

No imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
