### PR TITLE
Potential fix for code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -73,7 +73,11 @@ $(document).ready(function () {
     if (typeof prepComments === "function") prepComments();
 
     // For named anchors with the hrefit classname, make it a link as well
-    $(".hrefit").each(function() { t = $(this);  t.attr('href', '#' + t.attr('name')); });
+    $(".hrefit").each(function() {
+        t = $(this);
+        var anchorName = (t.attr('name') || '').replace(/[^A-Za-z0-9_\-:\.]/g, '');
+        t.attr('href', '#' + anchorName);
+    });
     $(".fetchme").each(function() { loadKillRow($(this).attr('killID'));  });
     setTimeout(fixCCPsBrokenImages, 1000);
 


### PR DESCRIPTION
Potential fix for [https://github.com/zKillboard/zKillboard/security/code-scanning/24](https://github.com/zKillboard/zKillboard/security/code-scanning/24)

General fix: never reuse DOM-derived text in URL/selector attributes without validation or encoding. For fragment links, sanitize to a strict allowed character set (or encode), then write the sanitized value.

Best fix here (minimal behavior change): in `public/js/common.js` at line 76, sanitize `t.attr('name')` before concatenating with `#`. Keep functionality (“make named anchors link to themselves”) while preventing unsafe characters from being interpreted in the resulting `href`.

Concretely:
- Read the name into a variable with default empty string.
- Strip disallowed characters (allow alphanumerics, `_`, `-`, `:`, `.` which are typical safe ID/name chars).
- Set `href` using the sanitized fragment only.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
