### PR TITLE
Potential fix for code scanning alert no. 32: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/asearch.js
+++ b/public/js/asearch.js
@@ -226,7 +226,7 @@ function getHTML(suggestion) {
 		.attr("id", suggestion.data.type + ':' + suggestion.data.id)
 		.attr("entity-id", suggestion.data.id)
 		.attr("entity-type", suggestion.data.type)
-		.html(suggestion.data.type.replace('ID', '') + ': ' + suggestion.value);
+		.text(suggestion.data.type.replace('ID', '') + ': ' + suggestion.value);
 	return $("<div>").attr('entity-type', suggestion.data.type).attr('entity-id', suggestion.data.id).append(left).append(data).append(right).append(remove).attr('time-id', 'id-' + Date.now()).addClass('filter').addClass('filter-' + suggestion.data.type);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/zKillboard/zKillboard/security/code-scanning/32](https://github.com/zKillboard/zKillboard/security/code-scanning/32)

General fix: stop writing untrusted strings through `.html()` and instead write as text (or build text nodes), so user-controlled content is not interpreted as HTML.

Best fix here (single-point, behavior-preserving): in `public/js/asearch.js` inside `getHTML`, replace:
- `.html(suggestion.data.type.replace('ID', '') + ': ' + suggestion.value);`
with:
- `.text(suggestion.data.type.replace('ID', '') + ': ' + suggestion.value);`

This preserves displayed content while preventing HTML parsing/execution, and addresses both alert variants since both flows end at the same sink. No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
