### PR TITLE
Potential fix for code scanning alert no. 34: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/asearch.js
+++ b/public/js/asearch.js
@@ -842,7 +842,7 @@ function btn_export() {
 		      </div>
 		      <div class="modal-body">
 		        <p>Copy the filter below to use in zkillbot:</p>
-		        <input type="text" class="form-control" id="zkillFilterInput" value="/zkillbot subscribe advanced:${filter}" readonly>
+		        <input type="text" class="form-control" id="zkillFilterInput" readonly>
 		      </div>
 		      <div class="modal-footer">
 		        <button type="button" class="btn btn-primary" id="copyZkillFilter">Copy to Clipboard</button>
@@ -851,6 +851,7 @@ function btn_export() {
 		  </div>
 		</div>
 	`);
+	modal.find('#zkillFilterInput').val('/zkillbot subscribe advanced:' + filter);
 	$('body').append(modal);
 	modal.modal('show');
 


### PR DESCRIPTION
Potential fix for [https://github.com/zKillboard/zKillboard/security/code-scanning/34](https://github.com/zKillboard/zKillboard/security/code-scanning/34)

The safest fix is to **stop interpolating untrusted data into an HTML string**. Keep the modal template static, append it to the DOM, and then assign the dynamic value using a safe text/value setter (`.val()` / `.value`) so content is treated as text, not HTML.

Best single fix in `public/js/asearch.js`:
- In `btn_export()`, replace the modal template so the `<input>` has no dynamic `value` interpolation.
- After creating `modal`, set `#zkillFilterInput`’s value programmatically:  
  `modal.find('#zkillFilterInput').val('/zkillbot subscribe advanced:' + filter);`
- This preserves existing behavior (same displayed/exported string, same modal/copy flow) while removing the HTML injection sink.

No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
