### PR TITLE
Include more pages in the isOverviewPathname to fix failing cases

### DIFF
--- a/public/js/overview.js
+++ b/public/js/overview.js
@@ -170,14 +170,8 @@ async function loadTops(token, pagePath, pageEntityID) {
 
 console.log('overview.js loaded');
 
-function isOverviewPath() {
-	return isOverviewPathname(window.location.pathname);
-}
-
-function isOverviewPathname(pathname) {
-	return /^\/(?:character|corporation|alliance|faction|ship|group|system|region|location)\/\d+(?:\/(?!page\/)[^/]+)*(?:\/page\/\d+)?\/?$/.test(pathname);
-}
-
 function isCurrentOverviewLoad(token, pagePath) {
-	return token === overviewLoadToken && pagePath === window.location.pathname && isOverviewPathname(pagePath);
+	return token === overviewLoadToken
+		&& pagePath === window.location.pathname
+		&& !!document.querySelector('#killlist');
 }

--- a/public/js/overview.js
+++ b/public/js/overview.js
@@ -175,7 +175,7 @@ function isOverviewPath() {
 }
 
 function isOverviewPathname(pathname) {
-	return /^\/(?:character|corporation|alliance|faction|ship|group|system|region|location)\/\d+\/(?:(?:kills|losses|solo|stats|wars|supers|trophies|ranks|top|topalltime|streambox|corpstats)\/?)?(?:page\/\d+\/?)?$/.test(pathname);
+	return /^\/(?:character|corporation|alliance|faction|ship|group|system|region|location)\/\d+(?:\/(?!page\/)[^/]+)*(?:\/page\/\d+)?\/?$/.test(pathname);
 }
 
 function isCurrentOverviewLoad(token, pagePath) {


### PR DESCRIPTION
The following overview pages aren't loading due to isOverviewPathname's regex not considering them.

Some examples
- https://zkillboard.com/system/30002541/reset/group/1657/losses/
- https://zkillboard.com/character/634915984/kills/highsec/

Fixes #371 